### PR TITLE
feat(vault): Phase 1.6 — Credential vault service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ test-results/
 # Kairos runtime
 data/
 snapshots/
-vault/
+/vault/
 *.db
 *.sqlite
 

--- a/DEV-CHECKLIST.md
+++ b/DEV-CHECKLIST.md
@@ -144,12 +144,12 @@ The phased plan from foundation through post-launch. Each item is actionable; ch
 
 ### 1.6 Vault
 
-- [ ] Vault service container (Python, age encryption)
-- [ ] Endpoints: `/resolve`, `/store`, `/metadata`, `/rotate`, `/aliases`, `/health`
-- [ ] HMAC auth on all internal calls
-- [ ] age master-key mount from host
-- [ ] Policy-engine gateway → vault; cognition never calls vault directly
-- [ ] `credential_access_log` write path
+- [x] Vault service container (Python, age encryption)
+- [x] Endpoints: `/resolve`, `/store`, `/metadata`, `/rotate`, `/aliases`, `/health`
+- [x] HMAC auth on all internal calls
+- [x] age master-key mount from host
+- [x] Policy-engine gateway → vault; cognition never calls vault directly
+- [x] `credential_access_log` write path
 
 ### 1.7 Run engine
 

--- a/services/control-plane/src/database/data-source.ts
+++ b/services/control-plane/src/database/data-source.ts
@@ -7,6 +7,7 @@ import { SelfState20260424000004 } from './migrations/20260424000004-self-state.
 import { Layer2State20260424000005 } from './migrations/20260424000005-layer2-state.js';
 import { Spans20260424000006 } from './migrations/20260424000006-spans.js';
 import { ApprovalsAddCancelled20260425000007 } from './migrations/20260425000007-approvals-add-cancelled.js';
+import { CredentialAccessLogAddAccessId20260425000008 } from './migrations/20260425000008-credential-access-log-access-id.js';
 import {
   AgentEntity,
   ApprovalEntity,
@@ -75,6 +76,7 @@ export const ALL_MIGRATIONS = [
   Layer2State20260424000005,
   Spans20260424000006,
   ApprovalsAddCancelled20260425000007,
+  CredentialAccessLogAddAccessId20260425000008,
 ] as const;
 
 export const AppDataSource = new DataSource({

--- a/services/control-plane/src/database/migrations/20260425000008-credential-access-log-access-id.ts
+++ b/services/control-plane/src/database/migrations/20260425000008-credential-access-log-access-id.ts
@@ -1,0 +1,19 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class CredentialAccessLogAddAccessId20260425000008 implements MigrationInterface {
+  name = 'CredentialAccessLogAddAccessId20260425000008';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE credential_access_log
+        ADD COLUMN IF NOT EXISTS access_id TEXT;
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE credential_access_log
+        DROP COLUMN IF EXISTS access_id;
+    `);
+  }
+}

--- a/services/control-plane/src/entities/credential-access-log.entity.ts
+++ b/services/control-plane/src/entities/credential-access-log.entity.ts
@@ -21,6 +21,9 @@ export class CredentialAccessLogEntity {
   @Column({ type: 'uuid', name: 'tool_execution_id', nullable: true })
   toolExecutionId!: string | null;
 
+  @Column({ type: 'text', name: 'access_id', nullable: true })
+  accessId!: string | null;
+
   @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
   createdAt!: Date;
 

--- a/services/control-plane/src/modules/policy/policy.module.ts
+++ b/services/control-plane/src/modules/policy/policy.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuditEventEntity } from '../../entities/audit-event.entity.js';
 import { PolicyRuleEntity } from '../../entities/policy-rule.entity.js';
+import { VaultModule } from '../vault/vault.module.js';
 import { CapabilityTokenService } from './capability-token.service.js';
 import { PolicyService } from './policy.service.js';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([AuditEventEntity, PolicyRuleEntity])],
+  imports: [TypeOrmModule.forFeature([AuditEventEntity, PolicyRuleEntity]), VaultModule],
   providers: [PolicyService, CapabilityTokenService],
-  exports: [PolicyService, CapabilityTokenService],
+  exports: [PolicyService, CapabilityTokenService, VaultModule],
 })
 export class PolicyModule {}

--- a/services/control-plane/src/modules/vault/__tests__/vault.service.spec.ts
+++ b/services/control-plane/src/modules/vault/__tests__/vault.service.spec.ts
@@ -1,0 +1,174 @@
+/**
+ * VaultService unit tests.
+ * Tests HMAC signing, resolve with access log, and error handling.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Repository } from 'typeorm';
+import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { CredentialAccessLogEntity } from '../../../entities/credential-access-log.entity.js';
+import { VaultService } from '../vault.service.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+type MockRepo<T extends object> = {
+  [K in keyof Repository<T>]: ReturnType<typeof vi.fn>;
+};
+
+function mockRepo<T extends object>(): MockRepo<T> {
+  return {
+    findOne: vi.fn(),
+    find: vi.fn(),
+    save: vi.fn((e: T) => Promise.resolve(e)),
+    create: vi.fn((e: Partial<T>) => e as T),
+    update: vi.fn(),
+    existsBy: vi.fn(),
+  } as unknown as MockRepo<T>;
+}
+
+function makeConfig(overrides: Record<string, string> = {}): ConfigService {
+  const defaults: Record<string, string> = {
+    VAULT_INTERNAL_URL: 'http://kairos-vault:8001',
+    VAULT_AUTH_SECRET: 'test-secret-99', // pragma: allowlist secret
+    ...overrides,
+  };
+  return {
+    getOrThrow: vi.fn((key: string) => {
+      if (!(key in defaults)) throw new Error(`Config key not found: ${key}`);
+      return defaults[key as string];
+    }),
+  } as unknown as ConfigService;
+}
+
+function makeService(
+  fetchMock: typeof globalThis.fetch,
+  repoOverrides?: Partial<MockRepo<CredentialAccessLogEntity>>,
+): VaultService {
+  vi.stubGlobal('fetch', fetchMock);
+  const repo = { ...mockRepo<CredentialAccessLogEntity>(), ...repoOverrides };
+  return new VaultService(makeConfig(), repo as unknown as Repository<CredentialAccessLogEntity>);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('VaultService.resolve', () => {
+  it('returns resolved value and writes access log', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ resolved: 'secret-val', access_id: 'acc-uuid-1' }),
+    });
+    const repo = mockRepo<CredentialAccessLogEntity>();
+    const service = makeService(fetchMock as unknown as typeof fetch, repo);
+
+    const result = await service.resolve({
+      alias: 'kairos-github-token',
+      caller: 'control-plane',
+      purpose: 'tool-dispatch',
+      runId: 'run-uuid-1',
+    });
+
+    expect(result.resolved).toBe('secret-val');
+    expect(result.accessId).toBe('acc-uuid-1');
+    expect(repo.save).toHaveBeenCalledOnce();
+
+    const logEntry = (repo.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as Partial<CredentialAccessLogEntity>;
+    expect(logEntry?.alias).toBe('kairos-github-token');
+    expect(logEntry?.callerService).toBe('control-plane');
+    expect(logEntry?.purpose).toBe('tool-dispatch');
+    expect(logEntry?.accessId).toBe('acc-uuid-1');
+    expect(logEntry?.runId).toBe('run-uuid-1');
+  });
+
+  it('throws NotFoundException when vault returns 404', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: vi.fn().mockResolvedValue({ detail: { code: 'unknown_alias', message: 'Alias not found: ghost' } }),
+    });
+    const service = makeService(fetchMock as unknown as typeof fetch);
+
+    await expect(
+      service.resolve({ alias: 'ghost', caller: 'cp', purpose: 'p' }),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws InternalServerErrorException when vault is unreachable', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const service = makeService(fetchMock as unknown as typeof fetch);
+
+    await expect(
+      service.resolve({ alias: 'k', caller: 'cp', purpose: 'p' }),
+    ).rejects.toThrow(InternalServerErrorException);
+  });
+
+  it('throws InternalServerErrorException when vault returns 500', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: vi.fn().mockResolvedValue('internal error'),
+    });
+    const service = makeService(fetchMock as unknown as typeof fetch);
+
+    await expect(
+      service.resolve({ alias: 'k', caller: 'cp', purpose: 'p' }),
+    ).rejects.toThrow(InternalServerErrorException);
+  });
+});
+
+describe('VaultService.store', () => {
+  it('returns storedAt on success', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: vi.fn().mockResolvedValue({ stored: true, created_at: '2026-04-25T00:00:00Z' }),
+    });
+    const service = makeService(fetchMock as unknown as typeof fetch);
+
+    const result = await service.store({
+      alias: 'new-alias',
+      value: 'some-value',
+      metadata: { description: 'Test alias' },
+    });
+
+    expect(result.storedAt).toBe('2026-04-25T00:00:00Z');
+  });
+});
+
+describe('VaultService.health', () => {
+  it('returns health status', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ status: 'ok', entries: 5, oldest_access_ms: 1000 }),
+    });
+    const service = makeService(fetchMock as unknown as typeof fetch);
+
+    const result = await service.health();
+
+    expect(result.status).toBe('ok');
+    expect(result.entries).toBe(5);
+    expect(result.oldestAccessMs).toBe(1000);
+  });
+});
+
+describe('VaultService signature', () => {
+  it('sends X-Internal-Signature header on POST requests', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ stored: true, created_at: '2026-04-25T00:00:00Z' }),
+    });
+    const service = makeService(fetchMock as unknown as typeof fetch);
+
+    await service.store({
+      alias: 'sig-test',
+      value: 'v',
+      metadata: { description: 'd' },
+    });
+
+    const [, init] = (fetchMock as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers['X-Internal-Signature']).toMatch(/^sha256=[0-9a-f]{64}$/);
+    expect(headers['X-Internal-Service']).toBe('control-plane');
+  });
+});

--- a/services/control-plane/src/modules/vault/vault.module.ts
+++ b/services/control-plane/src/modules/vault/vault.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CredentialAccessLogEntity } from '../../entities/credential-access-log.entity.js';
+import { VaultService } from './vault.service.js';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([CredentialAccessLogEntity])],
+  providers: [VaultService],
+  exports: [VaultService],
+})
+export class VaultModule {}

--- a/services/control-plane/src/modules/vault/vault.service.ts
+++ b/services/control-plane/src/modules/vault/vault.service.ts
@@ -1,0 +1,181 @@
+import { Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import * as crypto from 'node:crypto';
+import { Repository } from 'typeorm';
+import { CredentialAccessLogEntity } from '../../entities/credential-access-log.entity.js';
+
+export interface VaultResolveParams {
+  alias: string;
+  caller: string;
+  purpose: string;
+  runId?: string;
+  toolExecutionId?: string;
+}
+
+export interface VaultResolveResult {
+  resolved: string;
+  accessId: string;
+}
+
+export interface VaultStoreParams {
+  alias: string;
+  value: string;
+  metadata: {
+    description: string;
+    scope?: string;
+    rotation_interval_days?: number;
+  };
+}
+
+export interface VaultAliasMetadata {
+  alias: string;
+  description: string;
+  scope: string;
+  rotation_interval_days: number;
+  created_at: string;
+  rotates_at: string;
+  last_accessed: string | null;
+}
+
+@Injectable()
+export class VaultService {
+  private readonly logger = new Logger(VaultService.name);
+  private readonly vaultUrl: string;
+  private readonly authSecret: string;
+
+  constructor(
+    private readonly config: ConfigService,
+    @InjectRepository(CredentialAccessLogEntity)
+    private readonly accessLogRepo: Repository<CredentialAccessLogEntity>,
+  ) {
+    this.vaultUrl = this.config.getOrThrow<string>('VAULT_INTERNAL_URL');
+    this.authSecret = this.config.getOrThrow<string>('VAULT_AUTH_SECRET');
+  }
+
+  // ── resolve ─────────────────────────────────────────────────────────────────
+
+  async resolve(params: VaultResolveParams): Promise<VaultResolveResult> {
+    const { alias, caller, purpose, runId, toolExecutionId } = params;
+    const body = JSON.stringify({ alias, caller, purpose, run_id: runId ?? null, tool_execution_id: toolExecutionId ?? null });
+
+    const data = await this._post<{ resolved: string; access_id: string }>('/vault/resolve', body);
+
+    // Write credential access log
+    const entry = this.accessLogRepo.create({
+      alias,
+      callerService: caller,
+      purpose,
+      ...(runId != null ? { runId } : {}),
+      ...(toolExecutionId != null ? { toolExecutionId } : {}),
+      accessId: data.access_id,
+    });
+    await this.accessLogRepo.save(entry);
+
+    return { resolved: data.resolved, accessId: data.access_id };
+  }
+
+  // ── store ────────────────────────────────────────────────────────────────────
+
+  async store(params: VaultStoreParams): Promise<{ storedAt: string }> {
+    const body = JSON.stringify({
+      alias: params.alias,
+      value: params.value,
+      metadata: params.metadata,
+    });
+    const data = await this._post<{ stored: boolean; created_at: string }>('/vault/store', body);
+    return { storedAt: data.created_at };
+  }
+
+  // ── metadata ─────────────────────────────────────────────────────────────────
+
+  async metadata(alias: string): Promise<VaultAliasMetadata> {
+    const body = JSON.stringify({ alias });
+    return this._post<VaultAliasMetadata>('/vault/metadata', body);
+  }
+
+  // ── rotate ───────────────────────────────────────────────────────────────────
+
+  async rotate(alias: string, newValue?: string): Promise<{ rotatedAt: string; newRotatesAt: string }> {
+    const body = JSON.stringify({ alias, ...(newValue != null ? { new_value: newValue } : {}) });
+    const data = await this._post<{ rotated_at: string; new_rotates_at: string }>('/vault/rotate', body);
+    return { rotatedAt: data.rotated_at, newRotatesAt: data.new_rotates_at };
+  }
+
+  // ── aliases ──────────────────────────────────────────────────────────────────
+
+  async aliases(): Promise<VaultAliasMetadata[]> {
+    return this._get<VaultAliasMetadata[]>('/vault/aliases');
+  }
+
+  // ── health ───────────────────────────────────────────────────────────────────
+
+  async health(): Promise<{ status: string; entries: number; oldestAccessMs: number }> {
+    const data = await this._get<{ status: string; entries: number; oldest_access_ms: number }>('/vault/health');
+    return { status: data.status, entries: data.entries, oldestAccessMs: data.oldest_access_ms };
+  }
+
+  // ── internal helpers ──────────────────────────────────────────────────────────
+
+  private _sign(body: string): string {
+    const mac = crypto.createHmac('sha256', this.authSecret).update(body).digest('hex');
+    return `sha256=${mac}`;
+  }
+
+  private async _post<T>(path: string, body: string): Promise<T> {
+    const url = `${this.vaultUrl}${path}`;
+    let resp: Response;
+    try {
+      resp = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Internal-Service': 'control-plane',
+          'X-Internal-Signature': this._sign(body),
+        },
+        body,
+      });
+    } catch (err) {
+      this.logger.error(`Vault request failed: POST ${path}`, err);
+      throw new InternalServerErrorException({ code: 'vault_unreachable', message: 'Vault service unavailable' });
+    }
+
+    if (resp.status === 404) {
+      const detail = await resp.json() as { detail?: { message?: string } };
+      throw new NotFoundException({ code: 'unknown_alias', message: detail?.detail?.message ?? 'Alias not found' });
+    }
+
+    if (!resp.ok) {
+      const detail = await resp.text();
+      this.logger.error(`Vault error: POST ${path} → ${resp.status}`, detail);
+      throw new InternalServerErrorException({ code: 'vault_error', message: `Vault returned ${resp.status}` });
+    }
+
+    return resp.json() as Promise<T>;
+  }
+
+  private async _get<T>(path: string): Promise<T> {
+    const url = `${this.vaultUrl}${path}`;
+    let resp: Response;
+    try {
+      resp = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'X-Internal-Service': 'control-plane',
+          'X-Internal-Signature': this._sign(''),
+        },
+      });
+    } catch (err) {
+      this.logger.error(`Vault request failed: GET ${path}`, err);
+      throw new InternalServerErrorException({ code: 'vault_unreachable', message: 'Vault service unavailable' });
+    }
+
+    if (!resp.ok) {
+      const detail = await resp.text();
+      this.logger.error(`Vault error: GET ${path} → ${resp.status}`, detail);
+      throw new InternalServerErrorException({ code: 'vault_error', message: `Vault returned ${resp.status}` });
+    }
+
+    return resp.json() as Promise<T>;
+  }
+}

--- a/services/vault/Dockerfile
+++ b/services/vault/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1.7
+FROM python:3.12-slim AS base
+WORKDIR /app
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+RUN apt-get update && apt-get install -y --no-install-recommends tini curl \
+ && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir uv==0.4.18
+
+FROM base AS deps
+COPY pyproject.toml ./
+RUN uv pip install --system --no-cache -e . --group dev
+
+FROM deps AS dev
+ENV PYTHONPATH=/app/src
+COPY src ./src
+RUN mkdir -p /data/values
+EXPOSE 8001
+ENTRYPOINT ["/usr/bin/tini","--"]
+CMD ["uvicorn","kairos_vault.main:app","--host","0.0.0.0","--port","8001","--reload","--reload-dir","/app/src"]
+
+FROM base AS prod
+ENV PYTHONPATH=/app/src
+COPY pyproject.toml ./
+RUN uv pip install --system --no-cache -e .
+COPY src ./src
+RUN useradd -u 1000 -m kairos && mkdir -p /data/values && chown -R kairos:kairos /app /data
+USER kairos
+EXPOSE 8001
+ENTRYPOINT ["/usr/bin/tini","--"]
+CMD ["uvicorn","kairos_vault.main:app","--host","0.0.0.0","--port","8001"]

--- a/services/vault/README.md
+++ b/services/vault/README.md
@@ -1,0 +1,3 @@
+# kairos-vault
+
+Kairos credential vault service — age encryption, alias resolution, HMAC-auth.

--- a/services/vault/pyproject.toml
+++ b/services/vault/pyproject.toml
@@ -1,0 +1,53 @@
+[project]
+name = "kairos-vault"
+version = "0.0.0"
+requires-python = ">=3.12,<3.13"
+description = "Kairos credential vault service — age encryption, alias resolution, HMAC-auth"
+readme = "README.md"
+license = { text = "MIT" }
+dependencies = [
+  "fastapi>=0.110",
+  "uvicorn[standard]>=0.29",
+  "pydantic>=2.6",
+  "pydantic-settings>=2.2",
+  "structlog>=24.1",
+  "pyrage>=0.5",
+]
+
+[dependency-groups]
+dev = [
+  "pytest>=8.1",
+  "pytest-asyncio>=0.23",
+  "pytest-cov>=4.1",
+  "mypy>=1.9",
+  "ruff>=0.3",
+  "httpx>=0.27",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/kairos_vault"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+warn_return_any = true
+warn_unused_ignores = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+src = ["src"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM", "TCH", "RUF"]
+ignore = ["E501"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/services/vault/src/kairos_vault/__init__.py
+++ b/services/vault/src/kairos_vault/__init__.py
@@ -1,0 +1,1 @@
+"""Kairos vault service."""

--- a/services/vault/src/kairos_vault/auth.py
+++ b/services/vault/src/kairos_vault/auth.py
@@ -1,0 +1,40 @@
+"""HMAC authentication for internal vault requests."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+
+from fastapi import Header, HTTPException, Request, status
+
+_VAULT_AUTH_SECRET_ENV = "VAULT_AUTH_SECRET"  # pragma: allowlist secret
+
+
+def _get_auth_secret() -> bytes:
+    secret = os.environ.get(_VAULT_AUTH_SECRET_ENV, "")
+    if not secret:
+        raise RuntimeError(f"Environment variable {_VAULT_AUTH_SECRET_ENV} is not set")
+    return secret.encode()
+
+
+def _compute_signature(body: bytes) -> str:
+    mac = hmac.new(_get_auth_secret(), body, hashlib.sha256)
+    return f"sha256={mac.hexdigest()}"
+
+
+async def verify_internal_auth(
+    request: Request,
+    x_internal_signature: str = Header(..., alias="X-Internal-Signature"),
+    x_internal_service: str = Header(..., alias="X-Internal-Service"),
+) -> None:
+    """FastAPI dependency — verifies HMAC-SHA256 signature of the request body.
+
+    Raises HTTP 403 if the signature does not match or the auth secret is missing.
+    """
+    body = await request.body()
+    expected = _compute_signature(body)
+    if not hmac.compare_digest(expected.encode(), x_internal_signature.encode()):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"code": "forbidden", "message": "Invalid internal signature"},
+        )

--- a/services/vault/src/kairos_vault/crypto.py
+++ b/services/vault/src/kairos_vault/crypto.py
@@ -1,0 +1,55 @@
+"""age encryption/decryption using pyrage passphrase mode."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pyrage
+
+_MASTER_KEY_PATH = Path(os.environ.get("VAULT_MASTER_KEY_PATH", "/run/secrets/master.key"))
+_TEST_PASSPHRASE_ENV = "VAULT_TEST_PASSPHRASE"
+
+
+def _read_passphrase() -> str:
+    """Read master passphrase.
+
+    In tests, ``VAULT_TEST_PASSPHRASE`` env var is used instead of the key file.
+    In production, the key file must exist and be non-empty.
+    """
+    test_passphrase = os.environ.get(_TEST_PASSPHRASE_ENV)
+    if test_passphrase:
+        return test_passphrase
+
+    if not _MASTER_KEY_PATH.exists():
+        raise FileNotFoundError(
+            f"Master key not found at {_MASTER_KEY_PATH}. "
+            "Mount it read-only from the host."
+        )
+    passphrase = _MASTER_KEY_PATH.read_text().strip()
+    if not passphrase:
+        raise ValueError(f"Master key at {_MASTER_KEY_PATH} is empty")
+    return passphrase
+
+
+def encrypt(plaintext: bytes) -> bytes:
+    """Encrypt *plaintext* with the master passphrase and return age ciphertext."""
+    passphrase = _read_passphrase()
+    return pyrage.passphrase.encrypt(plaintext, passphrase)
+
+
+def decrypt(ciphertext: bytes) -> bytes:
+    """Decrypt age *ciphertext* using the master passphrase."""
+    passphrase = _read_passphrase()
+    return pyrage.passphrase.decrypt(ciphertext, passphrase)
+
+
+def validate_master_key() -> None:
+    """Smoke-test that the master key is readable and works for a round-trip.
+
+    Called at startup; raises on failure so the container exits loudly.
+    """
+    probe = b"kairos-vault-probe"
+    ct = encrypt(probe)
+    pt = decrypt(ct)
+    if pt != probe:
+        raise RuntimeError("Master key validation failed: round-trip mismatch")

--- a/services/vault/src/kairos_vault/main.py
+++ b/services/vault/src/kairos_vault/main.py
@@ -1,0 +1,46 @@
+"""Vault service entrypoint."""
+from __future__ import annotations
+
+import os
+import sys
+
+import structlog
+import uvicorn
+from fastapi import FastAPI
+
+from kairos_vault import crypto
+from kairos_vault.routes import aliases, health, metadata, resolve, rotate, store
+
+log = structlog.get_logger().bind(service="vault")
+
+app = FastAPI(title="kairos-vault", version="0.0.0")
+
+app.include_router(resolve.router, prefix="/vault")
+app.include_router(store.router, prefix="/vault")
+app.include_router(metadata.router, prefix="/vault")
+app.include_router(rotate.router, prefix="/vault")
+app.include_router(aliases.router, prefix="/vault")
+app.include_router(health.router, prefix="/vault")
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    try:
+        crypto.validate_master_key()
+    except Exception as exc:
+        log.error("vault.startup.key_validation_failed", error=str(exc))
+        sys.exit(1)
+    log.info("vault.startup", port=int(os.getenv("PORT", "8001")))
+
+
+def main() -> None:
+    uvicorn.run(
+        "kairos_vault.main:app",
+        host="0.0.0.0",
+        port=int(os.getenv("PORT", "8001")),
+        log_config=None,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/vault/src/kairos_vault/routes/__init__.py
+++ b/services/vault/src/kairos_vault/routes/__init__.py
@@ -1,0 +1,1 @@
+"""Route package."""

--- a/services/vault/src/kairos_vault/routes/aliases.py
+++ b/services/vault/src/kairos_vault/routes/aliases.py
@@ -1,0 +1,18 @@
+"""GET /vault/aliases — list all alias metadata."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from kairos_vault import storage
+from kairos_vault.auth import verify_internal_auth
+
+router = APIRouter()
+
+
+@router.get(
+    "/aliases",
+    response_model=list[storage.AliasMetadata],
+    dependencies=[Depends(verify_internal_auth)],
+)
+async def aliases() -> list[storage.AliasMetadata]:
+    return storage.list_aliases()

--- a/services/vault/src/kairos_vault/routes/health.py
+++ b/services/vault/src/kairos_vault/routes/health.py
@@ -1,0 +1,24 @@
+"""GET /vault/health — service health check (no auth required)."""
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from kairos_vault import storage
+
+router = APIRouter()
+
+
+class HealthResponse(BaseModel):
+    status: str
+    entries: int
+    oldest_access_ms: int
+
+
+@router.get("/health", response_model=HealthResponse)
+async def health() -> HealthResponse:
+    return HealthResponse(
+        status="ok",
+        entries=storage.count(),
+        oldest_access_ms=storage.oldest_access_ms(),
+    )

--- a/services/vault/src/kairos_vault/routes/metadata.py
+++ b/services/vault/src/kairos_vault/routes/metadata.py
@@ -1,0 +1,29 @@
+"""POST /vault/metadata — retrieve alias metadata."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from kairos_vault import storage
+from kairos_vault.auth import verify_internal_auth
+
+router = APIRouter()
+
+
+class MetadataRequest(BaseModel):
+    alias: str
+
+
+@router.post(
+    "/metadata",
+    response_model=storage.AliasMetadata,
+    dependencies=[Depends(verify_internal_auth)],
+)
+async def metadata(body: MetadataRequest) -> storage.AliasMetadata:
+    try:
+        return storage.get_metadata(body.alias)
+    except KeyError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "unknown_alias", "message": f"Alias not found: {body.alias}"},
+        )

--- a/services/vault/src/kairos_vault/routes/resolve.py
+++ b/services/vault/src/kairos_vault/routes/resolve.py
@@ -1,0 +1,39 @@
+"""POST /vault/resolve — look up and return a credential value."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from kairos_vault import storage
+from kairos_vault.auth import verify_internal_auth
+
+router = APIRouter()
+
+
+class ResolveRequest(BaseModel):
+    alias: str
+    caller: str
+    purpose: str
+    run_id: str | None = None
+    tool_execution_id: str | None = None
+
+
+class ResolveResponse(BaseModel):
+    resolved: str
+    access_id: str
+
+
+@router.post(
+    "/resolve",
+    response_model=ResolveResponse,
+    dependencies=[Depends(verify_internal_auth)],
+)
+async def resolve(body: ResolveRequest) -> ResolveResponse:
+    try:
+        value, access_id = storage.resolve(body.alias)
+    except KeyError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "unknown_alias", "message": f"Alias not found: {body.alias}"},
+        )
+    return ResolveResponse(resolved=value, access_id=access_id)

--- a/services/vault/src/kairos_vault/routes/rotate.py
+++ b/services/vault/src/kairos_vault/routes/rotate.py
@@ -1,0 +1,39 @@
+"""POST /vault/rotate — rotate the value of an alias."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from kairos_vault import storage
+from kairos_vault.auth import verify_internal_auth
+
+router = APIRouter()
+
+
+class RotateRequest(BaseModel):
+    alias: str
+    new_value: str | None = None
+
+
+class RotateResponse(BaseModel):
+    rotated_at: str
+    new_rotates_at: str
+
+
+@router.post(
+    "/rotate",
+    response_model=RotateResponse,
+    dependencies=[Depends(verify_internal_auth)],
+)
+async def rotate(body: RotateRequest) -> RotateResponse:
+    try:
+        meta = storage.rotate(body.alias, body.new_value)
+    except KeyError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "unknown_alias", "message": f"Alias not found: {body.alias}"},
+        )
+    rotated_at = datetime.now(UTC).isoformat()
+    return RotateResponse(rotated_at=rotated_at, new_rotates_at=meta.rotates_at)

--- a/services/vault/src/kairos_vault/routes/store.py
+++ b/services/vault/src/kairos_vault/routes/store.py
@@ -1,0 +1,44 @@
+"""POST /vault/store — persist a new credential alias."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from kairos_vault import storage
+from kairos_vault.auth import verify_internal_auth
+
+router = APIRouter()
+
+
+class StoreMeta(BaseModel):
+    description: str
+    scope: str = "global"
+    rotation_interval_days: int = 90
+
+
+class StoreRequest(BaseModel):
+    alias: str
+    value: str
+    metadata: StoreMeta
+
+
+class StoreResponse(BaseModel):
+    stored: bool
+    created_at: str
+
+
+@router.post(
+    "/store",
+    response_model=StoreResponse,
+    dependencies=[Depends(verify_internal_auth)],
+    status_code=status.HTTP_201_CREATED,
+)
+async def store(body: StoreRequest) -> StoreResponse:
+    try:
+        meta = storage.store(body.alias, body.value, body.metadata.model_dump())
+    except KeyError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": "alias_exists", "message": f"Alias already exists: {body.alias}"},
+        )
+    return StoreResponse(stored=True, created_at=meta.created_at)

--- a/services/vault/src/kairos_vault/storage.py
+++ b/services/vault/src/kairos_vault/storage.py
@@ -1,0 +1,190 @@
+"""Alias metadata and value storage backed by age-encrypted files."""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import tempfile
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+from kairos_vault import crypto
+
+_DATA_DIR = Path(os.environ.get("VAULT_DATA_DIR", "/data"))
+_VALUES_DIR = _DATA_DIR / "values"
+_ALIASES_FILE = _DATA_DIR / "aliases.json.age"
+
+
+class AliasMetadata(BaseModel):
+    alias: str
+    description: str
+    scope: str
+    rotation_interval_days: int
+    created_at: str  # ISO8601 UTC
+    rotates_at: str  # ISO8601 UTC
+    last_accessed: str | None  # ISO8601 UTC or null
+
+
+def _ensure_dirs() -> None:
+    _VALUES_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _value_path(alias: str) -> Path:
+    # Sanitize alias to prevent path traversal
+    safe = alias.replace("/", "_").replace("..", "__")
+    return _VALUES_DIR / f"{safe}.age"
+
+
+def _load_aliases_map() -> dict[str, Any]:
+    if not _ALIASES_FILE.exists():
+        return {}
+    ciphertext = _ALIASES_FILE.read_bytes()
+    raw = crypto.decrypt(ciphertext)
+    return json.loads(raw.decode())  # type: ignore[no-any-return]
+
+
+def _save_aliases_map(data: dict[str, Any]) -> None:
+    _ensure_dirs()
+    payload = json.dumps(data).encode()
+    ciphertext = crypto.encrypt(payload)
+    _atomic_write(_ALIASES_FILE, ciphertext)
+
+
+def _atomic_write(path: Path, data: bytes) -> None:
+    """Write *data* to *path* atomically using a temp file + rename."""
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".tmp-")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def store(alias: str, value: str, metadata: dict[str, Any]) -> AliasMetadata:
+    """Encrypt and store *value* for *alias*.
+
+    Raises ``KeyError`` if *alias* already exists.
+    """
+    _ensure_dirs()
+    aliases = _load_aliases_map()
+    if alias in aliases:
+        raise KeyError(f"Alias already exists: {alias}")
+
+    now = datetime.now(UTC)
+    interval = int(metadata.get("rotation_interval_days", 90))
+    rotates_at = now + timedelta(days=interval)
+
+    entry: dict[str, Any] = {
+        "alias": alias,
+        "description": str(metadata.get("description", "")),
+        "scope": str(metadata.get("scope", "global")),
+        "rotation_interval_days": interval,
+        "created_at": now.isoformat(),
+        "rotates_at": rotates_at.isoformat(),
+        "last_accessed": None,
+    }
+
+    # Encrypt value
+    ciphertext = crypto.encrypt(value.encode())
+    _atomic_write(_value_path(alias), ciphertext)
+
+    # Update alias map
+    aliases[alias] = entry
+    _save_aliases_map(aliases)
+
+    return AliasMetadata(**entry)
+
+
+def resolve(alias: str) -> tuple[str, str]:
+    """Return ``(plaintext_value, access_id)`` for *alias*.
+
+    ``access_id`` is a new UUID4 for audit correlation.
+    Raises ``KeyError`` if alias does not exist.
+    Updates ``last_accessed`` in the metadata map.
+    """
+    aliases = _load_aliases_map()
+    if alias not in aliases:
+        raise KeyError(f"Unknown alias: {alias}")
+
+    vp = _value_path(alias)
+    if not vp.exists():
+        raise KeyError(f"Value file missing for alias: {alias}")
+
+    ciphertext = vp.read_bytes()
+    plaintext = crypto.decrypt(ciphertext).decode()
+    access_id = str(uuid.uuid4())
+
+    # Update last_accessed
+    aliases[alias]["last_accessed"] = datetime.now(UTC).isoformat()
+    _save_aliases_map(aliases)
+
+    return plaintext, access_id
+
+
+def get_metadata(alias: str) -> AliasMetadata:
+    """Return metadata for *alias*. Raises ``KeyError`` if not found."""
+    aliases = _load_aliases_map()
+    if alias not in aliases:
+        raise KeyError(f"Unknown alias: {alias}")
+    return AliasMetadata(**aliases[alias])
+
+
+def list_aliases() -> list[AliasMetadata]:
+    """Return all alias metadata entries."""
+    aliases = _load_aliases_map()
+    return [AliasMetadata(**v) for v in aliases.values()]
+
+
+def rotate(alias: str, new_value: str | None = None) -> AliasMetadata:
+    """Replace the stored value for *alias*.
+
+    If *new_value* is ``None``, a random 32-byte hex secret is generated.
+    Updates ``rotates_at`` based on the alias's rotation interval.
+    Raises ``KeyError`` if alias does not exist.
+    """
+    aliases = _load_aliases_map()
+    if alias not in aliases:
+        raise KeyError(f"Unknown alias: {alias}")
+
+    value = new_value if new_value is not None else secrets.token_hex(32)
+    now = datetime.now(UTC)
+    interval = int(aliases[alias].get("rotation_interval_days", 90))
+    new_rotates_at = now + timedelta(days=interval)
+
+    ciphertext = crypto.encrypt(value.encode())
+    _atomic_write(_value_path(alias), ciphertext)
+
+    aliases[alias]["rotates_at"] = new_rotates_at.isoformat()
+    aliases[alias]["last_accessed"] = now.isoformat()
+    _save_aliases_map(aliases)
+
+    return AliasMetadata(**aliases[alias])
+
+
+def count() -> int:
+    """Return the total number of stored aliases."""
+    return len(_load_aliases_map())
+
+
+def oldest_access_ms() -> int:
+    """Return milliseconds since the oldest last_accessed, or 0 if none accessed."""
+    aliases = _load_aliases_map()
+    accesses = [
+        datetime.fromisoformat(v["last_accessed"])
+        for v in aliases.values()
+        if v.get("last_accessed")
+    ]
+    if not accesses:
+        return 0
+    oldest = min(accesses)
+    delta = datetime.now(UTC) - oldest
+    return int(delta.total_seconds() * 1000)

--- a/services/vault/tests/conftest.py
+++ b/services/vault/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Shared fixtures for vault tests."""
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+# Use a fixed test passphrase instead of the master key file
+os.environ.setdefault("VAULT_TEST_PASSPHRASE", "test-vault-passphrase-42")
+os.environ.setdefault("VAULT_AUTH_SECRET", "test-vault-auth-secret-99")
+
+
+@pytest.fixture()
+def tmp_data_dir(monkeypatch: pytest.MonkeyPatch) -> Generator[Path, None, None]:
+    """Provide a temporary /data directory and patch VAULT_DATA_DIR."""
+    with tempfile.TemporaryDirectory() as d:
+        data = Path(d)
+        (data / "values").mkdir()
+        monkeypatch.setenv("VAULT_DATA_DIR", str(data))
+        # Patch the module-level constants in storage
+        import kairos_vault.storage as s
+        monkeypatch.setattr(s, "_DATA_DIR", data)
+        monkeypatch.setattr(s, "_VALUES_DIR", data / "values")
+        monkeypatch.setattr(s, "_ALIASES_FILE", data / "aliases.json.age")
+        yield data

--- a/services/vault/tests/test_auth.py
+++ b/services/vault/tests/test_auth.py
@@ -1,0 +1,79 @@
+"""Tests for HMAC authentication."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from kairos_vault.main import app
+
+_SECRET = b"test-vault-auth-secret-99"
+
+
+def _sign(body: bytes) -> str:
+    mac = hmac.new(_SECRET, body, hashlib.sha256)
+    return f"sha256={mac.hexdigest()}"
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def test_health_requires_no_auth(client: TestClient) -> None:
+    resp = client.get("/vault/health")
+    assert resp.status_code == 200
+
+
+def test_resolve_requires_signature(client: TestClient) -> None:
+    resp = client.post(
+        "/vault/resolve",
+        json={"alias": "kairos-test", "caller": "test", "purpose": "test"},
+    )
+    # Missing X-Internal-Signature and X-Internal-Service headers → 422 (missing header)
+    assert resp.status_code == 422
+
+
+def test_resolve_rejects_bad_signature(client: TestClient) -> None:
+    body = json.dumps({"alias": "k", "caller": "cp", "purpose": "p"}).encode()
+    resp = client.post(
+        "/vault/resolve",
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Internal-Service": "control-plane",
+            "X-Internal-Signature": "sha256=badbadbadbad",
+        },
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["code"] == "forbidden"
+
+
+def test_resolve_accepts_valid_signature(
+    client: TestClient,
+    tmp_data_dir: object,
+) -> None:
+    """A correct signature passes auth (will 404 since alias not stored, not 403)."""
+    import kairos_vault.storage as s
+
+    s.store("kairos-test", "secret-value", {"description": "t", "scope": "global"})
+
+    body = json.dumps(
+        {"alias": "kairos-test", "caller": "control-plane", "purpose": "test-purpose"}
+    ).encode()
+    resp = client.post(
+        "/vault/resolve",
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Internal-Service": "control-plane",
+            "X-Internal-Signature": _sign(body),
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["resolved"] == "secret-value"
+    assert "access_id" in data

--- a/services/vault/tests/test_crypto.py
+++ b/services/vault/tests/test_crypto.py
@@ -1,0 +1,35 @@
+"""Tests for age crypto helpers."""
+from __future__ import annotations
+
+import pytest
+
+from kairos_vault import crypto
+
+
+def test_round_trip() -> None:
+    plaintext = b"hello vault"
+    ct = crypto.encrypt(plaintext)
+    assert ct != plaintext
+    pt = crypto.decrypt(ct)
+    assert pt == plaintext
+
+
+def test_validate_master_key() -> None:
+    # Should succeed with the test passphrase set in conftest
+    crypto.validate_master_key()
+
+
+def test_different_ciphertexts() -> None:
+    """Two encryptions of the same value should produce different ciphertexts (age is non-deterministic)."""
+    data = b"same-data"
+    ct1 = crypto.encrypt(data)
+    ct2 = crypto.encrypt(data)
+    # pyrage uses random work factors, so ciphertexts differ
+    assert ct1 != ct2
+
+
+def test_decrypt_wrong_passphrase(monkeypatch: pytest.MonkeyPatch) -> None:
+    ct = crypto.encrypt(b"data")
+    monkeypatch.setenv("VAULT_TEST_PASSPHRASE", "wrong-passphrase")
+    with pytest.raises(Exception):
+        crypto.decrypt(ct)

--- a/services/vault/tests/test_routes.py
+++ b/services/vault/tests/test_routes.py
@@ -1,0 +1,155 @@
+"""Integration tests for vault HTTP routes."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+import kairos_vault.storage as storage
+from kairos_vault.main import app
+
+_SECRET = b"test-vault-auth-secret-99"
+
+
+def _sign(body: bytes) -> str:
+    mac = hmac.new(_SECRET, body, hashlib.sha256)
+    return f"sha256={mac.hexdigest()}"
+
+
+def _headers(body: bytes) -> dict[str, str]:
+    return {
+        "Content-Type": "application/json",
+        "X-Internal-Service": "control-plane",
+        "X-Internal-Signature": _sign(body),
+    }
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(app, raise_server_exceptions=True)
+
+
+# ── /vault/health ─────────────────────────────────────────────────────────────
+
+
+def test_health(client: TestClient, tmp_data_dir: object) -> None:
+    resp = client.get("/vault/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["entries"] == 0
+
+
+# ── /vault/store ──────────────────────────────────────────────────────────────
+
+
+def test_store_creates_alias(client: TestClient, tmp_data_dir: object) -> None:
+    body = json.dumps({
+        "alias": "kairos-smtp-pass",
+        "value": "smtp-secret-value",  # pragma: allowlist secret
+        "metadata": {"description": "SMTP password", "scope": "global"},
+    }).encode()
+    resp = client.post("/vault/store", content=body, headers=_headers(body))
+    assert resp.status_code == 201
+    assert resp.json()["stored"] is True
+
+
+def test_store_conflict(client: TestClient, tmp_data_dir: object) -> None:
+    body = json.dumps({
+        "alias": "conflict-alias",
+        "value": "v",
+        "metadata": {"description": "d"},
+    }).encode()
+    client.post("/vault/store", content=body, headers=_headers(body))
+    resp = client.post("/vault/store", content=body, headers=_headers(body))
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "alias_exists"
+
+
+# ── /vault/resolve ────────────────────────────────────────────────────────────
+
+
+def test_resolve_returns_value(client: TestClient, tmp_data_dir: object) -> None:
+    storage.store("resolve-test", "my-secret", {"description": "R"})  # pragma: allowlist secret
+
+    body = json.dumps({
+        "alias": "resolve-test",
+        "caller": "control-plane",
+        "purpose": "tool-dispatch",
+    }).encode()
+    resp = client.post("/vault/resolve", content=body, headers=_headers(body))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["resolved"] == "my-secret"  # pragma: allowlist secret
+    assert "access_id" in data
+
+
+def test_resolve_unknown(client: TestClient, tmp_data_dir: object) -> None:
+    body = json.dumps(
+        {"alias": "ghost", "caller": "cp", "purpose": "p"}
+    ).encode()
+    resp = client.post("/vault/resolve", content=body, headers=_headers(body))
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "unknown_alias"
+
+
+# ── /vault/metadata ───────────────────────────────────────────────────────────
+
+
+def test_metadata(client: TestClient, tmp_data_dir: object) -> None:
+    storage.store("meta-alias", "v", {"description": "Meta desc", "scope": "ws-1"})
+
+    body = json.dumps({"alias": "meta-alias"}).encode()
+    resp = client.post("/vault/metadata", content=body, headers=_headers(body))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["alias"] == "meta-alias"
+    assert data["scope"] == "ws-1"
+
+
+def test_metadata_unknown(client: TestClient, tmp_data_dir: object) -> None:
+    body = json.dumps({"alias": "nope"}).encode()
+    resp = client.post("/vault/metadata", content=body, headers=_headers(body))
+    assert resp.status_code == 404
+
+
+# ── /vault/rotate ─────────────────────────────────────────────────────────────
+
+
+def test_rotate(client: TestClient, tmp_data_dir: object) -> None:
+    storage.store("rotate-alias", "old", {"description": "Rotate me"})
+
+    body = json.dumps({"alias": "rotate-alias", "new_value": "new-val"}).encode()
+    resp = client.post("/vault/rotate", content=body, headers=_headers(body))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "rotated_at" in data
+    assert "new_rotates_at" in data
+
+    # Value should be updated
+    value, _ = storage.resolve("rotate-alias")
+    assert value == "new-val"
+
+
+# ── /vault/aliases ────────────────────────────────────────────────────────────
+
+
+def test_aliases_list(client: TestClient, tmp_data_dir: object) -> None:
+    storage.store("al1", "v1", {"description": "A1"})
+    storage.store("al2", "v2", {"description": "A2"})
+
+    body = b""
+    resp = client.get(
+        "/vault/aliases",
+        headers={
+            "X-Internal-Service": "control-plane",
+            "X-Internal-Signature": _sign(body),
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 2
+    assert {a["alias"] for a in data} == {"al1", "al2"}

--- a/services/vault/tests/test_storage.py
+++ b/services/vault/tests/test_storage.py
@@ -1,0 +1,92 @@
+"""Tests for alias storage operations."""
+from __future__ import annotations
+
+import pytest
+
+import kairos_vault.storage as storage
+
+
+def test_store_and_resolve(tmp_data_dir: object) -> None:
+    meta = storage.store(
+        "kairos-github-token",
+        "ghp_test000000000000",  # pragma: allowlist secret
+        {"description": "GitHub PAT", "scope": "global", "rotation_interval_days": 90},
+    )
+    assert meta.alias == "kairos-github-token"
+    assert meta.last_accessed is None
+
+    value, access_id = storage.resolve("kairos-github-token")
+    assert value == "ghp_test000000000000"  # pragma: allowlist secret
+    assert len(access_id) == 36  # UUID4
+
+    # last_accessed updated
+    meta2 = storage.get_metadata("kairos-github-token")
+    assert meta2.last_accessed is not None
+
+
+def test_store_duplicate_raises(tmp_data_dir: object) -> None:
+    storage.store("dup-alias", "val1", {"description": "d"})
+    with pytest.raises(KeyError, match="already exists"):
+        storage.store("dup-alias", "val2", {"description": "d"})
+
+
+def test_resolve_unknown_raises(tmp_data_dir: object) -> None:
+    with pytest.raises(KeyError, match="Unknown alias"):
+        storage.resolve("no-such-alias")
+
+
+def test_get_metadata(tmp_data_dir: object) -> None:
+    storage.store("meta-test", "v", {"description": "Meta test", "scope": "workspace-x"})
+    meta = storage.get_metadata("meta-test")
+    assert meta.scope == "workspace-x"
+    assert meta.rotation_interval_days == 90
+
+
+def test_list_aliases_empty(tmp_data_dir: object) -> None:
+    assert storage.list_aliases() == []
+
+
+def test_list_aliases(tmp_data_dir: object) -> None:
+    storage.store("a1", "v1", {"description": "A1"})
+    storage.store("a2", "v2", {"description": "A2"})
+    aliases = storage.list_aliases()
+    assert {a.alias for a in aliases} == {"a1", "a2"}
+
+
+def test_rotate(tmp_data_dir: object) -> None:
+    storage.store("rotate-me", "old-value", {"description": "R"})
+    meta = storage.rotate("rotate-me", new_value="new-value")
+    assert meta.rotates_at != ""
+
+    value, _ = storage.resolve("rotate-me")
+    assert value == "new-value"
+
+
+def test_rotate_generates_value_if_none(tmp_data_dir: object) -> None:
+    storage.store("auto-rotate", "initial", {"description": "AR"})
+    storage.rotate("auto-rotate", new_value=None)
+    value, _ = storage.resolve("auto-rotate")
+    # Generated value should be 64 hex chars (32 bytes)
+    assert len(value) == 64
+    assert value != "initial"
+
+
+def test_rotate_unknown_raises(tmp_data_dir: object) -> None:
+    with pytest.raises(KeyError, match="Unknown alias"):
+        storage.rotate("ghost-alias")
+
+
+def test_count(tmp_data_dir: object) -> None:
+    assert storage.count() == 0
+    storage.store("c1", "v", {"description": "C1"})
+    assert storage.count() == 1
+    storage.store("c2", "v", {"description": "C2"})
+    assert storage.count() == 2
+
+
+def test_alias_path_sanitization(tmp_data_dir: object) -> None:
+    """Path traversal attempt is sanitized."""
+    storage.store("../evil", "bad", {"description": "evil"})
+    # Should not escape the values dir
+    value, _ = storage.resolve("../evil")
+    assert value == "bad"


### PR DESCRIPTION
## Phase 1.6 — Credential Vault

### What
- **Python FastAPI vault service** (`services/vault/`) with age passphrase encryption via `pyrage`
- HMAC-SHA256 authentication on all internal endpoints (`X-Internal-Signature: sha256=<hex>`)
- Full endpoint suite: `/resolve`, `/store`, `/metadata`, `/rotate`, `/aliases`, `/health`
- Atomic file writes: `tempfile.mkstemp` + `os.replace()`
- **VaultService** + **VaultModule** in control-plane — policy engine is the sole gateway to vault
- `credential_access_log` write path on every `/resolve` call (with `access_id` correlation)
- Migration `20260425000008`: adds `access_id` column to `credential_access_log`
- Fix `.gitignore`: scope `vault/` to repo root only (not `services/vault/`)

### Tests
- 28 Python tests (auth, crypto, routes, storage) — all passing
- 7 TS unit tests for VaultService — all passing
- 177 total TS tests passing (9 test files)